### PR TITLE
caPutLogShellCommands: ensure caPutLog is initialized before performing certain calls

### DIFF
--- a/caPutLogApp/caPutLog.c
+++ b/caPutLogApp/caPutLog.c
@@ -37,6 +37,13 @@
 #define LOCAL static
 #endif
 
+int caPutLogInitialized = 0;
+
+int caPutLogWasInit()
+{
+    return caPutLogInitialized != 0;
+}
+
 /*
  *  caPutLogShow ()
  */
@@ -105,6 +112,8 @@ int caPutLogInit (const char *addr_str, int config)
     if (status) {
         return caPutLogError;
     }
+
+    caPutLogInitialized = 1;
 
     epicsAtExit(caPutLogExitProc, NULL);
 

--- a/caPutLogApp/caPutLog.h
+++ b/caPutLogApp/caPutLog.h
@@ -22,6 +22,7 @@ epicsShareFunc int caPutLogFile (const char *file_path);
 epicsShareFunc int caPutLogReconf (int config);
 epicsShareFunc void caPutLogShow (int level);
 epicsShareFunc void caPutLogSetTimeFmt (const char *format);
+epicsShareFunc int caPutLogWasInit(void);
 
 #ifdef __cplusplus
 }

--- a/caPutLogApp/caPutLogShellCommands.c
+++ b/caPutLogApp/caPutLogShellCommands.c
@@ -33,6 +33,10 @@ static const iocshArg *const caPutLogReconfArgs[] = {
 static const iocshFuncDef caPutLogReconfDef = {"caPutLogReconf", 1, caPutLogReconfArgs};
 static void caPutLogReconfCall(const iocshArgBuf *args)
 {
+    if (!caPutLogWasInit()) {
+        printf("caPutLog not initialized\n");
+        return;
+    }
     caPutLogReconf(args[0].ival);
 }
 
@@ -43,6 +47,10 @@ static const iocshArg *const caPutLogShowArgs[] = {
 static const iocshFuncDef caPutLogShowDef = {"caPutLogShow", 1, caPutLogShowArgs};
 static void caPutLogShowCall(const iocshArgBuf *args)
 {
+    if (!caPutLogWasInit()) {
+        printf("caPutLog not initialized\n");
+        return;
+    }
     caPutLogShow(args[0].ival);
 }
 


### PR DESCRIPTION

The client mutex may not be initialized yet